### PR TITLE
Update CMakeLists.txt to handle WebAssembly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,20 @@
 cmake_minimum_required(VERSION 3.1)
 project(tetgen)
 
-option(BUILD_EXECUTABLE "Build tetgen executable" OFF)
+option(BUILD_EXECUTABLE "Build tetgen executable" ON)
 option(BUILD_LIBRARY    "Build libtetgen library" ON)
 
 if(BUILD_LIBRARY)
   add_library(tetgen STATIC tetgen.cxx predicates.cxx)
   target_compile_definitions(tetgen PRIVATE -DTETLIBRARY)
-  # Generate position independent code
   set_target_properties(tetgen PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
-
 
 if(BUILD_EXECUTABLE)
   add_executable(tetgen_exec tetgen.cxx predicates.cxx)
   set_target_properties(tetgen_exec PROPERTIES OUTPUT_NAME tetgen)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+    set_target_properties(tetgen_exec PROPERTIES SUFFIX ".html")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s EXPORTED_RUNTIME_METHODS=['callMain'] -sSTACK_SIZE=131072 -s TOTAL_MEMORY=64MB")
+  endif()
 endif()


### PR DESCRIPTION
Hi, I would like to suggest adding a script to build tetgen with webassembly so that it can be used in web projects.
Here’s a summary of the changes made to the CMakeLists.txt file:

1. Build Options Adjustment:

- Original: The BUILD_EXECUTABLE option was set to OFF by default.
- Modified: I changed the BUILD_EXECUTABLE option to ON by default, since static tetgen.js, tetgen.wasm files needed for web projects. If this modification is improper for standard tetgen users, update readme for web users is required.

2. Emscripten-Specific Enhancements:

New Condition Added: 
I added a condition to check if the build system is Emscripten. This lets us apply specific settings when targeting WebAssembly.

HTML Output for Emscripten:
- Original: There was no specific handling for Emscripten.
- Modified: When building with Emscripten, the output file for the tetgen executable now gets a .html suffix instead of the usual executable format.

Emscripten Compiler Flags:
New Flags: I included several flags to improve the WebAssembly build:
EXPORTED_RUNTIME_METHODS=['callMain']: This makes sure the callMain method is available in the runtime, so we can call the main function from JavaScript.
-sSTACK_SIZE=131072: I increased the stack size to 131072 bytes to avoid stack overflow issues during complex operations.
-s TOTAL_MEMORY=64MB: I set the total memory allocation to 64MB to prevent out-of-memory errors while running the WebAssembly module.

Best Regards